### PR TITLE
Changes Rendering Behaviour of RMA Document

### DIFF
--- a/lib/gentle/documents/request/rma_document.rb
+++ b/lib/gentle/documents/request/rma_document.rb
@@ -32,7 +32,7 @@ module Gentle
                       'TrackingNumber' => @rma.tracking_number) do
 
                 @rma.returned_items.each do |returned_item|
-                  xml.Line('LineNo'          => returned_item.line_item_id,
+                  xml.Line('LineNo'          => returned_item.id,
                            'OrderNumber'     => @order.number,
                            'ItemNumber'      => returned_item.sku,
                            'Quantity'        => returned_item.quantity,


### PR DESCRIPTION
We can't use the line-item ID corresponding to each return-item as the `LineNo` attribute of `RMA/Line` nodes. This attribute must be unique, and there's an `n:1` relationship between return-items and order line-items.
