### PR TITLE
Fix/128807481 rma duplicate line item id quantity

### DIFF
--- a/lib/gentle/documents/request/rma_document.rb
+++ b/lib/gentle/documents/request/rma_document.rb
@@ -31,11 +31,11 @@ module Gentle
                       'Warehouse'      => warehouse,
                       'TrackingNumber' => @rma.tracking_number) do
 
-                @rma.returned_items.each do |returned_item|
-                  xml.Line('LineNo'          => returned_item.line_item_id,
+                @rma.returned_items.each_with_index do |returned_item, line_number|
+                  xml.Line('LineNo'          => line_number + 1,
                            'OrderNumber'     => @order.number,
                            'ItemNumber'      => returned_item.sku,
-                           'Quantity'        => returned_item.quantity,
+                           'Quantity'        => 1,
                            'SaleUOM'         => 'EA', #Each
                            'ReturnReason'    => @rma.reason.name,
                            'CustomerComment' => ''

--- a/spec/fixtures/documents/responses/shipment_order_result.xml
+++ b/spec/fixtures/documents/responses/shipment_order_result.xml
@@ -17,7 +17,7 @@
     ServiceLevel="FIRST"
     TrackingId="40000000000"
     Weight="0.66">
-    <Content Line="1"Quantity="1" />
-    <Content Line="2"Quantity="1" />
+    <Content Line="1" Quantity="1" />
+    <Content Line="2" Quantity="1" />
   </Carton>
 </SOResult>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -269,33 +269,18 @@ class ReasonDouble
   end
 end
 
-class InventoryUnitDouble
-  attr_accessor :variant, :line_item, :line_item_id
-
-  DEFAULT_OPTIONS = {
-      line_item_id: 1,
-      line_item: LineItemDouble.example,
-      variant: VariantDouble.example
-  }
-  def initialize(options = {})
-    @line_item_id = options[:line_item_id]
-    @line_item    = options[:line_item]
-    @variant      = options[:variant]
-  end
-  def self.example(options = {})
-    self.new(DEFAULT_OPTIONS.merge(options))
-  end
-end
 
 class ReturnItemDouble
-  attr_accessor :inventory_unit
+  attr_accessor :sku
 
   DEFAULT_OPTIONS = {
-      inventory_unit: InventoryUnitDouble.example,
+      sku: "ABC-123",
   }
+
   def initialize(options = {})
-    @inventory_unit = options[:inventory_unit]
+    @sku = options[:sku]
   end
+
   def self.example(options = {})
     self.new(DEFAULT_OPTIONS.merge(options))
   end
@@ -303,6 +288,7 @@ end
 
 class RMADouble
   attr_accessor :return_items, :order, :config, :reason, :number, :tracking_number, :created_at
+  alias_method :returned_items, :return_items
 
   DEFAULT_OPTIONS = {
       number: 'RMA1234567',

--- a/spec/unit/documents/request/rma_document_spec.rb
+++ b/spec/unit/documents/request/rma_document_spec.rb
@@ -37,17 +37,28 @@ module Gentle
 
           line_items = document.css('Line')
           assert_equal 1, line_items.length
-          assert_line_item(@order.line_items.first, line_items.first)
+          assert_line_item("1", @order.line_items.first, line_items.first)
         end
 
+        it "should create 1 line for each returned item" do
+          @rma.return_items = [ReturnItemDouble.example, ReturnItemDouble.example]
+          @object = @RMADocument = RMADocument.new(config: @config, rma: @rma)
+
+          document = Nokogiri::XML::Document.parse(@RMADocument.to_xml)
+          line_items = document.css('Line')
+          assert_equal 2, line_items.length
+          assert_line_item("1", @order.line_items.first, line_items.first)
+          assert_line_item("2", @order.line_items.first, line_items.last)
+
+        end
 
         private
 
-        def assert_line_item(expected_line_item, line_item)
-          assert_equal "1", line_item['LineNo']
+        def assert_line_item(line_number, expected_line_item, line_item)
+          assert_equal line_number, line_item['LineNo']
           assert_equal  @order.number, line_item['OrderNumber']
           assert_equal expected_line_item.sku.to_s, line_item['ItemNumber']
-          assert_equal expected_line_item.quantity.to_s, line_item['Quantity']
+          assert_equal "1", line_item['Quantity']
           assert_equal "EA", line_item['SaleUOM']
           assert_equal @rma.reason.name, line_item['ReturnReason']
           assert_equal "", line_item['CustomerComment']

--- a/spec/unit/documents/response/shipment_order_result_spec.rb
+++ b/spec/unit/documents/response/shipment_order_result_spec.rb
@@ -14,7 +14,7 @@ module Gentle
           assert_equal 'Gentle', order_result.client_id
           assert_equal 'Gentle', order_result.business_unit
           assert_equal 1, order_result.carton_count
-          assert_equal Time.new(2009, 9, 1, 0, 0, 0).utc, order_result.date_shipped
+          assert_equal Time.utc(2009, 9, 1, 4, 0, 0), order_result.date_shipped
 
           assert_equal "40000000000", order_result.tracking_number
           assert_equal "FIRST", order_result.service_level


### PR DESCRIPTION
Hi, @hugobast this PR fixes the issue of duplicated line items in the RMARequest document.
Also, a failing shipment related spec has been updated, and useless test doubles have been removed. 

Merging this means we can delete this one https://github.com/DynamoMTL/gentle/pull/2
