### PR TITLE
Extracts new information from the filename on errors

### DIFF
--- a/lib/gentle/error_message.rb
+++ b/lib/gentle/error_message.rb
@@ -10,10 +10,20 @@ module Gentle
       @xml.serialize(encoding: "UTF-8")
     end
 
-    def shipment_number
-      result_description = @xml.css("ErrorMessage").first["ResultDescription"]
-      match_data = result_description.match(/(.+)_(.+)_(.+)_.*.xml/) unless result_description.nil?
-      match_data[2] unless match_data.nil?
+    def identifier
+      filename[2]
+    end
+    alias_method :shipment_number, :identifier
+
+    def object_type
+      filename[1] unless filename.nil?
+    end
+
+    def result_description
+      @result_description ||= @xml.css("ErrorMessage").first["ResultDescription"]
+    end
+    def filename
+      @filename ||= result_description.split('_') unless result_description.nil?
     end
   end
 end

--- a/lib/gentle/version.rb
+++ b/lib/gentle/version.rb
@@ -1,3 +1,3 @@
 module Gentle
-  VERSION = "0.3"
+  VERSION = "0.3.1"
 end

--- a/spec/unit/error_message_spec.rb
+++ b/spec/unit/error_message_spec.rb
@@ -14,8 +14,12 @@ module Gentle
       assert_equal normalize(@xml_content), normalize(@message.to_xml)
     end
 
-    it "extracts the shipment number from the error message" do
-      assert_equal "H123456789", @message.shipment_number
+    it "extracts the identifier from the error message" do
+      assert_equal "H123456789", @message.identifier
+    end
+
+    it "extracts the object type from the error message" do
+      assert_equal "ShipmentOrder", @message.object_type
     end
 
     it "returns nil for shipment number if it cannot find it" do


### PR DESCRIPTION
Hi,
@hugobast Gentle has now to deal with RMAs as well as Shipments.
 This PR extracts more information from the filename, and stops assuming the error is coming from a `Shipment`, allowing the error handlers to act according to the type of object they are interacting with.
